### PR TITLE
feat: platform parallel-run bridge + pytest revival (epic #111)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .pytest_cache
 build/
 scripts/creds.sh
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ Make sure dependencies are installed: `pipenv install`
 ```
 scripts/deploy.sh <dev | prod>
 ```
+
+## Parallel-run platform bridge
+
+While the new tournament platform runs alongside this legacy bot, the
+`checkin`, `sort_signups` and `results` handlers mirror their events to the
+platform's `/legacy/*` endpoints (see `src/libs/platform.py`). The bridge is
+**fire-and-forget and fail-open**: the call is made synchronously after the
+Discord reply, with a short timeout, and every failure is swallowed so the
+bot is never affected.
+
+It is configured via two stack parameters (set as environment variables for
+Sceptre, alongside the existing `GOOGLE_API_KEY` etc.):
+
+| Variable                | Stack parameter      | Purpose                                                                 |
+| ----------------------- | -------------------- | ----------------------------------------------------------------------- |
+| `PLATFORM_BASE_URL_DEV` / `PLATFORM_BASE_URL_PROD` | `PlatformBaseUrl`   | Base URL of the platform API Worker, e.g. `https://api.example.com`.    |
+| `LEGACY_BRIDGE_SECRET`  | `LegacyBridgeSecret` | Shared secret; sent in the `x-legacy-bridge-secret` header. Must match the platform's `LEGACY_BRIDGE_SECRET`. |
+
+Leave `PlatformBaseUrl` (or the secret) empty to disable the bridge — the
+notifier then simply no-ops.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Runs on Lambda functions exposed via API Gateway written in Troposphere and depl
     └── tests
 ```
 
+Run the test suite:
+
+`src/tests` holds characterization tests that pin the current behaviour of
+the `checkin`, `manage` and `results` handlers. All external services
+(Google Sheets, Challonge, boto3/SSM, Discord) are mocked; no test makes a
+real network call.
+
+```
+# one-time setup
+python3 -m venv .venv
+.venv/bin/pip install pytest pytest-mock pytest-env pynacl gspread requests boto3
+
+# run the suite (config lives in pytest.ini)
+.venv/bin/pytest
+```
+
+With the project dependencies already installed (e.g. via `pipenv install`)
+the suite also runs with a plain `pytest` from the repo root.
+
 Update Discord slash commands:
 
 ```

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -8,3 +8,5 @@ parameters:
   GoogleSheetId: {{ environment_variable.GOOGLE_SHEET_ID_DEV }}
   ChallongeApiKey: {{ environment_variable.CHALLONGE_API_KEY }}
   AlertWebhook: {{ environment_variable.ALERT_WEBHOOK }}
+  PlatformBaseUrl: {{ environment_variable.PLATFORM_BASE_URL_DEV }}
+  LegacyBridgeSecret: {{ environment_variable.LEGACY_BRIDGE_SECRET }}

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -8,3 +8,5 @@ parameters:
   GoogleSheetId: {{ environment_variable.GOOGLE_SHEET_ID_PROD }}
   ChallongeApiKey: {{ environment_variable.CHALLONGE_API_KEY }}
   AlertWebhook: {{ environment_variable.ALERT_WEBHOOK }}
+  PlatformBaseUrl: {{ environment_variable.PLATFORM_BASE_URL_PROD }}
+  LegacyBridgeSecret: {{ environment_variable.LEGACY_BRIDGE_SECRET }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,4 +22,5 @@ env =
     LAMBDA_MANAGE=test-lambda-manage
     LAMBDA_RESULTS=test-lambda-results
     DISCORD_PUBLIC_KEY=0000000000000000000000000000000000000000000000000000000000000000
+    # Decodes to `{"type":"service_account"}` -- a stub placeholder, not a real key.
     GOOGLE_API_KEY=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50In0=

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,25 @@
+[pytest]
+# Characterization-test suite for the legacy Discord bot.
+# Run with:  .venv/bin/pytest      (or: pytest, with deps installed)
+#
+# `pythonpath = src` lets the handler packages resolve their absolute
+# imports (e.g. `from libs.constants import *`, `from manage import main`).
+pythonpath = src
+testpaths = src/tests
+python_files = test_*.py
+
+# Handler modules read configuration from os.environ at *import* time, so
+# every variable they touch must be present before collection runs.
+# pytest-env injects these. None point at a real service.
+env =
+    DEBUG=false
+    APPLICATION_ID=test-application-id
+    ALERT_WEBHOOK=https://example.invalid/webhook
+    CHECKIN_STATUS_PARAM=test-checkin-status-param
+    CHALLONGE_API_KEY=test-challonge-key
+    GOOGLE_SHEET_ID=test-google-sheet-id
+    LAMBDA_CHECKIN=test-lambda-checkin
+    LAMBDA_MANAGE=test-lambda-manage
+    LAMBDA_RESULTS=test-lambda-results
+    DISCORD_PUBLIC_KEY=0000000000000000000000000000000000000000000000000000000000000000
+    GOOGLE_API_KEY=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50In0=

--- a/src/checkin/main.py
+++ b/src/checkin/main.py
@@ -129,16 +129,22 @@ def lambda_handler(event, context):
         logging.debug(response)
         checkin_status = response["Parameter"]["Value"]
 
+        checkin_succeeded = False
         if checkin_status == "disabled":
             message = f":no_entry: Tournament checkins are not currently open"
         else:
             message = checkin(event, checkin_status)
+            # `checkin()` returns a `:white_check_mark:`-prefixed string only
+            # on the success path; every failure mode returns `:no_entry:`.
+            checkin_succeeded = message.startswith(":white_check_mark:")
 
         discord.message_response(message)
 
         # Parallel-run bridge: mirror the check-in to the new platform AFTER
-        # the Discord reply. Fail-open -- never affects the handler.
-        if checkin_status != "disabled":
+        # the Discord reply. Only fires for check-ins that actually happened,
+        # consistent with the `results`/`sort` hooks. Fail-open -- never
+        # affects the handler.
+        if checkin_succeeded:
             try:
                 post_to_platform(
                     "/legacy/checkin", build_checkin_payload(event, checkin_status)

--- a/src/checkin/main.py
+++ b/src/checkin/main.py
@@ -10,6 +10,7 @@ import boto3
 from libs.constants import *
 from libs.discord import Discord
 from libs.gsheets import GoogleSheet
+from libs.platform import post_to_platform
 
 # Google SA setup: https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account
 
@@ -93,6 +94,29 @@ def checkin(event, checkin_status):
     return f":white_check_mark: `{query_name}` checked in!"
 
 
+def build_checkin_payload(event, checkin_status):
+    """Build the `/legacy/checkin` bridge payload from a check-in event.
+
+    Mirrors how `checkin()` itself reads the event: a `team` sub-command
+    carries a team name; a `solo` sub-command carries a player name (with
+    the same nick -> global_name -> username fallback) and, when available,
+    the interaction's Discord user id to bootstrap Player identity.
+    """
+    sub_command = event["data"]["options"][0]["name"]
+    if sub_command == "team":
+        team_name = event["data"]["options"][0]["options"][0]["value"]
+        return {"team_name": team_name, "day": checkin_status}
+
+    member = event.get("member", {})
+    user = member.get("user", {})
+    player_name = member.get("nick") or user.get("global_name") or user.get("username")
+    payload = {"player_name": player_name, "day": checkin_status}
+    discord_user_id = user.get("id")
+    if discord_user_id:
+        payload["discord_user_id"] = discord_user_id
+    return payload
+
+
 def lambda_handler(event, context):
     logging.debug(json.dumps(event))
 
@@ -111,6 +135,16 @@ def lambda_handler(event, context):
             message = checkin(event, checkin_status)
 
         discord.message_response(message)
+
+        # Parallel-run bridge: mirror the check-in to the new platform AFTER
+        # the Discord reply. Fail-open -- never affects the handler.
+        if checkin_status != "disabled":
+            try:
+                post_to_platform(
+                    "/legacy/checkin", build_checkin_payload(event, checkin_status)
+                )
+            except Exception as bridge_error:  # noqa: BLE001 -- belt-and-braces
+                logging.warning("Platform bridge hook failed: %s", bridge_error)
     except Exception as e:
         logging.exception(e)
         discord.exception_alert(ALERT_WEBHOOK, context)

--- a/src/libs/platform.py
+++ b/src/libs/platform.py
@@ -68,6 +68,12 @@ def post_to_platform(path, payload):
         logging.debug("Platform bridge not configured; skipping %s", path)
         return False
 
+    if not path:
+        # Defensive: a caller passing an empty path would otherwise POST to
+        # the base URL itself. No legitimate call site does this.
+        logging.warning("Platform bridge called with empty path; skipping")
+        return False
+
     url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
 
     try:

--- a/src/libs/platform.py
+++ b/src/libs/platform.py
@@ -1,0 +1,88 @@
+"""
+Parallel-run notifier for the new tournament platform (issue #118).
+
+During the one-way parallel-run bridge, the legacy Discord bot mirrors a few
+events to the new Cloudflare-Worker tournament platform via its `/legacy/*`
+endpoints. `post_to_platform` is the single helper used for that.
+
+It is **synchronous and fail-open by design**:
+
+* Synchronous, because the AWS Lambda execution environment freezes the
+  moment the handler returns -- a background thread would never run. The
+  call is therefore made inline, but only AFTER the handler's existing work
+  and the Discord reply, so it adds no user-visible latency.
+* Short-timeout, so a slow/unreachable platform can never stall the handler.
+* Fail-open: every failure mode (timeout, connection error, HTTP non-2xx,
+  or anything else) is caught and swallowed. The helper never raises and
+  never affects the calling handler.
+
+Configuration -- both sourced from the Lambda environment (populated from
+the Sceptre/CloudFormation stack parameters, same as the bot's other
+secrets / config; see ``templates/template.py`` and ``config/*/config.yaml``):
+
+* ``PLATFORM_BASE_URL``   -- base URL of the platform API Worker, e.g.
+                             ``https://api.example.com``. Endpoint paths are
+                             joined onto it (``/legacy/checkin`` etc.).
+* ``LEGACY_BRIDGE_SECRET`` -- shared secret; sent in the
+                             ``x-legacy-bridge-secret`` request header. Must
+                             match the value the platform stores under the
+                             same name. Marked ``NoEcho`` in the stack.
+
+If either value is unset the helper simply no-ops -- the bridge is optional
+and its absence must never break the bot.
+"""
+import logging
+import os
+
+import requests
+
+# Header the platform's `/legacy/*` endpoints expect the shared secret in.
+BRIDGE_SECRET_HEADER = "x-legacy-bridge-secret"
+
+# Short timeout (seconds): connect + read. The platform call is best-effort;
+# it must never hold up the Lambda handler.
+REQUEST_TIMEOUT = 3
+
+
+def post_to_platform(path, payload):
+    """Fire-and-forget POST of an event to a platform `/legacy/*` endpoint.
+
+    Args:
+        path: endpoint path, e.g. ``"/legacy/checkin"`` (leading slash
+            optional -- it is normalised against ``PLATFORM_BASE_URL``).
+        payload: JSON-serialisable request body.
+
+    Returns:
+        ``True`` if the platform accepted the event with a 2xx response,
+        ``False`` for every other outcome (unconfigured, timeout, connection
+        error, non-2xx, or any unexpected error).
+
+    This function never raises; the caller is unaffected by any failure.
+    """
+    base_url = os.environ.get("PLATFORM_BASE_URL")
+    secret = os.environ.get("LEGACY_BRIDGE_SECRET")
+
+    if not base_url or not secret:
+        # Bridge not configured -- silently skip. This is expected before the
+        # platform is wired up and must not break the bot.
+        logging.debug("Platform bridge not configured; skipping %s", path)
+        return False
+
+    url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    try:
+        res = requests.post(
+            url,
+            json=payload,
+            headers={BRIDGE_SECRET_HEADER: secret},
+            timeout=REQUEST_TIMEOUT,
+        )
+        res.raise_for_status()
+        logging.info("Platform bridge: %s -> %s", path, res.status_code)
+        return True
+    except Exception as e:  # noqa: BLE001 -- fail-open: swallow EVERYTHING
+        # Timeout, connection error, HTTP non-2xx, or anything unexpected.
+        # The bridge is best-effort; log for the parallel-run audit and
+        # carry on as if nothing happened.
+        logging.warning("Platform bridge call to %s failed (swallowed): %s", path, e)
+        return False

--- a/src/manage/main.py
+++ b/src/manage/main.py
@@ -13,6 +13,7 @@ from libs.challonge import Challonge
 from libs.constants import *
 from libs.discord import Discord
 from libs.gsheets import GoogleSheet
+from libs.platform import post_to_platform
 
 if os.getenv("DEBUG") == "true":
     logging.getLogger().setLevel(logging.DEBUG)
@@ -156,7 +157,15 @@ def generate_divisions(teams, solos):
     )
 
 
-def sort_signups(event, gsheet, challonge):
+def sort_signups(event, gsheet, challonge, divisions_out=None):
+    """Sort tournament sign-ups into divisions.
+
+    `divisions_out`, when given, is a mutable list the function appends the
+    generated division layout to. It lets `lambda_handler` mirror the sorted
+    divisions to the parallel-run platform bridge *without* changing the
+    return value or any existing behaviour -- the three-argument calls in the
+    characterization suite are unaffected.
+    """
     if not event["data"]["options"][0]["options"][0]["value"]:
         return "Cancelled"
 
@@ -180,6 +189,9 @@ def sort_signups(event, gsheet, challonge):
     divisions, playing_teams, _, excluded_teams, excluded_solos = generate_divisions(
         teams, solos
     )
+
+    if divisions_out is not None:
+        divisions_out.extend(divisions)
 
     # TODO add try/except
     # Write divs to team list sheet
@@ -208,6 +220,32 @@ def sort_signups(event, gsheet, challonge):
     return message
 
 
+def build_sort_payload(divisions):
+    """Build the `/legacy/sort` bridge payload from the division layout.
+
+    `divisions` is the list-of-lists `generate_divisions` produced; each
+    inner list is already in seed order (descending rating), so the payload
+    preserves that order per division.
+    """
+    return {
+        "divisions": [
+            {
+                "division_number": i + 1,
+                "teams": [
+                    {
+                        "team_name": team["team"],
+                        "player_1": team["player_1"],
+                        "player_2": team["player_2"],
+                        "rating": team["rating"],
+                    }
+                    for team in division
+                ],
+            }
+            for i, division in enumerate(divisions)
+        ]
+    }
+
+
 def lambda_handler(event, context):
     logging.debug(json.dumps(event))
 
@@ -217,6 +255,7 @@ def lambda_handler(event, context):
         discord = Discord(APPLICATION_ID, event["token"])
         gsheet = GoogleSheet(GOOGLE_API_KEY, GOOGLE_SHEET_ID, SIGNUP_SHEET)
 
+        sort_divisions = []
         sub_command = event["data"]["options"][0]["name"]
         if sub_command == "checkin_status":
             current_status = get_checkin_status(client, CHECKIN_STATUS_PARAM)
@@ -231,11 +270,20 @@ def lambda_handler(event, context):
         elif sub_command == "clear_spreadsheets":
             message = clear_google_sheets(gsheet, event)
         elif sub_command == "sort_signups":
-            message = sort_signups(event, gsheet, challonge)
+            message = sort_signups(event, gsheet, challonge, sort_divisions)
         else:
             raise Exception(f"{sub_command} is not a valid command")
 
         discord.message_response(message)
+
+        # Parallel-run bridge: mirror the sorted divisions to the new
+        # platform AFTER the Discord reply. Only fires when `sort_signups`
+        # actually produced a division layout. Fail-open.
+        if sub_command == "sort_signups" and sort_divisions:
+            try:
+                post_to_platform("/legacy/sort", build_sort_payload(sort_divisions))
+            except Exception as bridge_error:  # noqa: BLE001 -- belt-and-braces
+                logging.warning("Platform bridge hook failed: %s", bridge_error)
     except Exception as e:
         logging.exception(e)
         discord.exception_alert(ALERT_WEBHOOK, context)

--- a/src/results/main.py
+++ b/src/results/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from libs.challonge import Challonge
 from libs.constants import *
 from libs.discord import Discord
+from libs.platform import post_to_platform
 
 if os.getenv("DEBUG") == "true":
     logging.getLogger().setLevel(logging.DEBUG)
@@ -36,7 +37,16 @@ def find_losing_team_id(participants, id):
         return None
 
 
-def results(event, context, tournament_id):
+def results(event, context, tournament_id, result_out=None):
+    """Record a self-reported match result on Challonge.
+
+    `result_out`, when given, is a mutable dict the function populates on the
+    success path with the recorded `winning_team_name`, `winning_score` and
+    `losing_score`. It lets `lambda_handler` mirror a confirmed result to the
+    parallel-run platform bridge without changing the return value or any
+    existing behaviour -- the three-argument calls in the characterization
+    suite are unaffected.
+    """
     winning_team = event["data"]["options"][0]["value"]
     winning_score = event["data"]["options"][1]["value"]
     losing_score = event["data"]["options"][2]["value"]
@@ -127,6 +137,16 @@ def results(event, context, tournament_id):
     )
 
     losing_team = challonge._get_participant(tournament_id, losing_team_id)
+
+    if result_out is not None:
+        result_out.update(
+            {
+                "winning_team_name": winning_team_name,
+                "winning_score": winning_score,
+                "losing_score": losing_score,
+            }
+        )
+
     return f":white_check_mark: [Round {latest_match['match']['round']}] `{winning_team_name}` {winning_score}-{losing_score} `{losing_team['participant']['name']}`"
 
 
@@ -139,8 +159,18 @@ def lambda_handler(event, context):
         channel_id = event["channel_id"]
         tournament_id = RESULTS_CHANNEL_IDS[channel_id]
 
-        message = results(event, context, tournament_id)
+        recorded_result = {}
+        message = results(event, context, tournament_id, recorded_result)
         discord.message_response(message)
+
+        # Parallel-run bridge: mirror a confirmed result to the new platform
+        # AFTER the Discord reply. `recorded_result` is only populated on the
+        # success path (a score was actually recorded). Fail-open.
+        if recorded_result:
+            try:
+                post_to_platform("/legacy/results", recorded_result)
+            except Exception as bridge_error:  # noqa: BLE001 -- belt-and-braces
+                logging.warning("Platform bridge hook failed: %s", bridge_error)
     except Exception as e:
         logging.exception(e)
         discord.exception_alert(ALERT_WEBHOOK, context)

--- a/src/tests/test_checkin.py
+++ b/src/tests/test_checkin.py
@@ -10,8 +10,6 @@ class the handler imports -- no test touches a real spreadsheet or network.
 """
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from checkin import main
 
 

--- a/src/tests/test_checkin.py
+++ b/src/tests/test_checkin.py
@@ -1,0 +1,199 @@
+"""
+Characterization tests for the `checkin` handler.
+
+These pin the *current* behaviour of the unmodified `checkin` function:
+the team and solo check-in paths, the already-checked-in short-circuit, and
+the name-not-found short-circuit.
+
+Google Sheets (gspread) is mocked at the boundary via the `GoogleSheet`
+class the handler imports -- no test touches a real spreadsheet or network.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from checkin import main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+# A channel id that constants.py maps to the "Sign-up" sheet.
+SIGNUP_CHANNEL_ID = "1023401872750547014"
+
+
+def _cell(row=2, address="K2", value=""):
+    """A stand-in for a gspread Cell."""
+    cell = MagicMock()
+    cell.row = row
+    cell.address = address
+    cell.value = value
+    return cell
+
+
+def solo_event(player_nick="Alice", channel_id=SIGNUP_CHANNEL_ID):
+    return {
+        "data": {"options": [{"name": "solo"}]},
+        "member": {
+            "nick": player_nick,
+            "user": {"global_name": "AliceGlobal", "username": "alice_user"},
+        },
+        "channel_id": channel_id,
+    }
+
+
+def team_event(
+    player_nick="Bob", team_name="Team Rocket", channel_id=SIGNUP_CHANNEL_ID
+):
+    return {
+        "data": {
+            "options": [
+                {"name": "team", "options": [{"name": "team", "value": team_name}]}
+            ]
+        },
+        "member": {
+            "nick": player_nick,
+            "user": {"global_name": "BobGlobal", "username": "bob_user"},
+        },
+        "channel_id": channel_id,
+    }
+
+
+def make_worksheet(name_cell=None, status_value="", player_in_row=True):
+    """Build a mock gspread worksheet.
+
+    `worksheet.find` is called with keyword args `in_column` (name lookup) or
+    `in_row` (team-membership lookup); dispatch on which is present.
+    """
+    worksheet = MagicMock()
+    status_cell = _cell(row=2, address="K2", value=status_value)
+
+    def find(query=None, case_sensitive=None, in_column=None, in_row=None):
+        if in_row is not None:
+            return _cell() if player_in_row else None
+        return name_cell
+
+    worksheet.find.side_effect = find
+    worksheet.cell.return_value = status_cell
+    return worksheet
+
+
+# ---------------------------------------------------------------------------
+# Solo path
+# ---------------------------------------------------------------------------
+@patch("checkin.main.GoogleSheet")
+def test_checkin_solo_success(mock_gsheet_cls):
+    worksheet = make_worksheet(name_cell=_cell(row=5), status_value="")
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(solo_event(player_nick="Alice"), "day_1")
+
+    assert message == ":white_check_mark: `Alice` checked in!"
+    # The status cell is written for the solo day_1 column (COLUMNS["solo"]["day_1"]).
+    worksheet.update_cell.assert_called_once_with(5, 11, "Checked In")
+    worksheet.format.assert_called_once()
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_solo_already_checked_in(mock_gsheet_cls):
+    worksheet = make_worksheet(name_cell=_cell(row=5), status_value="Checked In")
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(solo_event(player_nick="Alice"), "day_1")
+
+    assert message == ":no_entry: `Alice` is already checked in"
+    worksheet.update_cell.assert_not_called()
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_solo_name_not_found(mock_gsheet_cls):
+    worksheet = make_worksheet(name_cell=None)
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(solo_event(player_nick="Ghost"), "day_1")
+
+    assert message.startswith(":no_entry: `Ghost` not found in the `Sign-up` sheet")
+    worksheet.update_cell.assert_not_called()
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_solo_falls_back_to_global_name(mock_gsheet_cls):
+    """When `nick` is empty the handler falls back to the user global_name."""
+    worksheet = make_worksheet(name_cell=_cell(row=3), status_value="")
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    event = solo_event(player_nick="")  # nick falsy -> use global_name
+    message = main.checkin(event, "day_1")
+
+    assert message == ":white_check_mark: `AliceGlobal` checked in!"
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_solo_blocked_on_day_2(mock_gsheet_cls):
+    """Solo check-ins are rejected outright on day_2 (no sheet access)."""
+    message = main.checkin(solo_event(), "day_2")
+
+    assert message == ":no_entry: Solo players should check in as their team on Day 2"
+    mock_gsheet_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Team path
+# ---------------------------------------------------------------------------
+@patch("checkin.main.GoogleSheet")
+def test_checkin_team_success(mock_gsheet_cls):
+    worksheet = make_worksheet(
+        name_cell=_cell(row=7), status_value="", player_in_row=True
+    )
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(team_event(team_name="Team Rocket"), "day_1")
+
+    assert message == ":white_check_mark: `Team Rocket` checked in!"
+    # Team day_1 status column is COLUMNS["team"]["day_1"].
+    worksheet.update_cell.assert_called_once_with(7, 6, "Checked In")
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_team_already_checked_in(mock_gsheet_cls):
+    worksheet = make_worksheet(
+        name_cell=_cell(row=7), status_value="Checked In", player_in_row=True
+    )
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(team_event(team_name="Team Rocket"), "day_1")
+
+    assert message == ":no_entry: `Team Rocket` is already checked in"
+    worksheet.update_cell.assert_not_called()
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_team_name_not_found(mock_gsheet_cls):
+    worksheet = make_worksheet(name_cell=None)
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(team_event(team_name="Nonexistent"), "day_1")
+
+    assert message.startswith(
+        ":no_entry: `Nonexistent` not found in the `Sign-up` sheet"
+    )
+    worksheet.update_cell.assert_not_called()
+
+
+@patch("checkin.main.GoogleSheet")
+def test_checkin_team_player_not_on_team(mock_gsheet_cls):
+    """Team found, but the requesting player is not in its row."""
+    worksheet = make_worksheet(
+        name_cell=_cell(row=7), status_value="", player_in_row=False
+    )
+    mock_gsheet_cls.return_value.worksheet = worksheet
+
+    message = main.checkin(
+        team_event(player_nick="Bob", team_name="Team Rocket"), "day_1"
+    )
+
+    assert message == (
+        ":no_entry: Player `Bob` is not on team `Team Rocket`\n"
+        "Please make sure your Discord nickname matches your in game name"
+    )
+    worksheet.update_cell.assert_not_called()

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -1,104 +1,71 @@
-# import json
-# import os
-# from unittest.mock import patch
-# import pytest
+"""
+Characterization tests for the front-door `handler`.
 
-# import nacl.signing
-# from nacl.encoding import HexEncoder
-# from nacl.exceptions import BadSignatureError
-# from nacl.public import PrivateKey
-# import boto3
+These pin the *current* behaviour of the unmodified handler: Discord
+ed25519 signature verification (the Discord boundary) and the pure
+`discord_body` response shaper.
 
-# from handler import main
+No test makes a real network or API call.
+"""
+import json
+from unittest.mock import patch
 
+import nacl.signing
 
-# private_key = PrivateKey.generate()
-
-# event = {
-#     "body": "",
-#     "headers": {"x-signature-ed25519": "", "x-signature-timestamp": ""},
-# }
+from handler import main
 
 
-# @pytest.fixture(autouse=True)
-# def env_setup(monkeypatch):
-#     monkeypatch.setenv("DISCORD_PUBLIC_KEY", hex(private_key.public_key))
-#     monkeypatch.setenv("LAMBDA_CHECKIN", "lambda_checkin")
-#     monkeypatch.setenv("LAMBDA_MANAGE", "lambda_manage")
-#     monkeypatch.setenv("LAMBDA_RESULTS", "lambda_results")
-#     monkeypatch.setenv("ALERT_WEBHOOK", "WEBHOOK")
+def _signed_event(signing_key, body, timestamp="1700000000"):
+    """Produce an event whose ed25519 signature is valid for `signing_key`."""
+    signature = signing_key.sign(
+        (timestamp + body).encode()
+    ).signature.hex()
+    return {
+        "body": body,
+        "headers": {
+            "x-signature-ed25519": signature,
+            "x-signature-timestamp": timestamp,
+        },
+    }
 
 
-# def test_valid_signature():
-#     body = '{"type": 1}'
-#     event["body"] = body
-#     signed_message = (event["headers"]["x-signature-timestamp"] + body).encode()
-#     vk = nacl.signing.VerifyKey(os.environ["DISCORD_PUBLIC_KEY"], encoder=HexEncoder)
-#     signature = vk.sign(signed_message).signature.hex()
-#     event["headers"]["x-signature-ed25519"] = signature
-#     valid = main.run.valid_signature(event)
-#     assert valid == True
+def test_discord_body_shape():
+    response = main.discord_body(200, 2, "test message")
+    assert response == {
+        "statusCode": 200,
+        "body": json.dumps(
+            {"type": 2, "data": {"tts": False, "content": "test message"}}
+        ),
+    }
 
 
-# def test_invalid_signature():
-#     body = '{"type": 1}'
-#     event["body"] = body
-#     event["headers"]["x-signature-ed25519"] = "invalid_signature"
-#     valid = main.run.valid_signature(event)
-#     assert valid == False
+def test_valid_signature_accepts_correctly_signed_request():
+    signing_key = nacl.signing.SigningKey.generate()
+    public_key_hex = signing_key.verify_key.encode().hex()
+    body = '{"type": 1}'
+    event = _signed_event(signing_key, body)
+
+    with patch.object(main, "DISCORD_PUBLIC_KEY", public_key_hex):
+        assert main.valid_signature(event) is True
 
 
-# def test_discord_body():
-#     message = "test message"
-#     response = main.run.discord_body(200, 2, message)
-#     expected_response = {
-#         "statusCode": 200,
-#         "body": json.dumps({"type": 2, "data": {"tts": False, "content": message}}),
-#     }
-#     assert response == expected_response
+def test_valid_signature_rejects_tampered_body():
+    signing_key = nacl.signing.SigningKey.generate()
+    public_key_hex = signing_key.verify_key.encode().hex()
+    event = _signed_event(signing_key, '{"type": 1}')
+    # Tamper with the body after signing -> signature no longer matches.
+    event["body"] = '{"type": 2}'
+
+    with patch.object(main, "DISCORD_PUBLIC_KEY", public_key_hex):
+        assert main.valid_signature(event) is False
 
 
-# @patch.dict(os.environ, {"DEBUG": "true"})
-# def test_logging_debug_level():
-#     assert main.run.logging.getLogger().getEffectiveLevel() == 10
+def test_valid_signature_rejects_garbage_signature():
+    signing_key = nacl.signing.SigningKey.generate()
+    public_key_hex = signing_key.verify_key.encode().hex()
+    event = _signed_event(signing_key, '{"type": 1}')
+    # 64-byte hex string that is not a valid signature for this message.
+    event["headers"]["x-signature-ed25519"] = "00" * 64
 
-
-# @patch.dict(os.environ, {"DEBUG": "false"})
-# def test_logging_info_level():
-#     assert main.run.logging.getLogger().getEffectiveLevel() == 20
-
-
-# @patch("boto3.client")
-# def test_invoke_lambda(mocked_lambda_client):
-#     event["body"] = '{"type": 2, "data": {"name": "manage"}}'
-#     command_func = "lambda_manage"
-#     response = {"StatusCode": 202}
-#     mocked_lambda_client.return_value.invoke.return_value = response
-#     result = main.run.run(event, None)
-#     mocked_lambda_client.assert_called_once()
-#     mocked_lambda_client.assert_called_with("lambda")
-#     assert result["statusCode"] == 200
-#     assert result["body"] == json.dumps(
-#         {"type": 5, "data": {"tts": False, "content": "processing"}}
-#     )
-
-
-# def test_handle_signup_command():
-#     event["body"] = '{"type": 2, "data": {"name": "signup"}}'
-#     result = main.run.run(event, None)
-#     assert result["statusCode"] == 200
-#     assert "FAQ" in result["body"]
-
-
-# def test_handle_invalid_command():
-#     event["body"] = '{"type": 2, "data": {"name": "invalid_command"}}'
-#     result = main.run.run(event, None)
-#     assert result["statusCode"] == 200
-#     assert "Unable to" in result["body"]
-
-
-# def test_handle_type1_command():
-#     event["body"] = '{"type": 1}'
-#     result = main.run.run(event, None)
-#     assert result["statusCode"] == 200
-#     assert result["body"] == json.dumps({"type": 1})
+    with patch.object(main, "DISCORD_PUBLIC_KEY", public_key_hex):
+        assert main.valid_signature(event) is False

--- a/src/tests/test_manage.py
+++ b/src/tests/test_manage.py
@@ -1,36 +1,52 @@
+"""
+Characterization tests for the `manage` handler.
+
+These tests pin the *current* behaviour of the unmodified handler so that a
+later, additive change can be proven behaviour-preserving. They are not a
+specification of desired behaviour -- if the handler changes, the expected
+values here are what must be re-derived from the real code.
+
+Every external service (boto3 / SSM, Google Sheets, Challonge) is mocked at
+the boundary; no test makes a real network or API call.
+"""
 import random
 from unittest.mock import MagicMock
 
 import pytest
+from requests.exceptions import HTTPError
 
-# from libs.challonge import Challonge
 from manage import main
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 def generate_checkins(num_teams, num_solos):
+    """Build deterministic-shaped team/solo check-in dicts.
+
+    `generate_divisions` only branches on *counts* and relative rating order,
+    so the random ratings here do not affect the division *sizes* that the
+    characterization assertions below pin.
+    """
     teams = []
     for i in range(num_teams):
-        team_name = f"Team {i+1}"
-        player_1 = f"Player {2*i+1}"
-        player_2 = f"Player {2*i+2}"
-        rating = random.randint(1400, 2400)
-        team = {
-            "team": team_name,
-            "player_1": player_1,
-            "player_2": player_2,
-            "rating": rating,
-        }
-        teams.append(team)
+        teams.append(
+            {
+                "team": f"Team {i + 1}",
+                "player_1": f"Player {2 * i + 1}",
+                "player_2": f"Player {2 * i + 2}",
+                "rating": random.randint(1400, 2400),
+            }
+        )
 
     solos = []
     for i in range(num_solos):
-        player = f"Player {2*num_teams+i+1}"
-        rating = random.randint(800, 2800)
-        solo = {
-            "player": player,
-            "rating": rating,
-        }
-        solos.append(solo)
+        solos.append(
+            {
+                "player": f"Player {2 * num_teams + i + 1}",
+                "rating": random.randint(800, 2800),
+            }
+        )
 
     return teams, solos
 
@@ -38,11 +54,7 @@ def generate_checkins(num_teams, num_solos):
 def run_generate_divisions(
     i_teams,
     i_solos,
-    o_divs_0,
-    o_divs_1,
-    o_divs_2,
-    o_divs_3,
-    o_divs_4,
+    o_div_sizes,
     o_playing_teams,
     o_playing_solos,
     o_excluded_teams,
@@ -57,49 +69,16 @@ def run_generate_divisions(
         excluded_solos,
     ) = main.generate_divisions(teams, solos)
 
-    assert len(divisions[0]) == o_divs_0
-    assert len(divisions[1]) == o_divs_1
-    assert len(divisions[2]) == o_divs_2
-    assert len(divisions[3]) == o_divs_3
-    assert len(divisions[4]) == o_divs_4
+    assert [len(d) for d in divisions] == o_div_sizes
     assert len(playing_teams) == o_playing_teams
     assert len(playing_solos) == o_playing_solos
     assert len(excluded_teams) == o_excluded_teams
     assert len(excluded_solos) == o_excluded_solos
 
 
-# class MockGsheet:
-#     def __init__(self, num_teams, num_solos):
-#         self.num_teams = num_teams
-#         self.num_solos = num_solos
-
-#     def get_all_checkins(self):
-#         teams, solos = generate_checkins(self.num_teams, self.num_solos)
-#         return teams, solos
-
-#     def write_teams_to_div_sheets(self, divisions):
-#         return True
-
-
-# class MockChallonge:
-#     def add_participants_to_tournament(self, divisions):
-#         return True
-
-
-# @pytest.fixture(autouse=True)
-# def env_setup(monkeypatch):
-#     monkeypatch.setenv("CHECKIN_STATUS_PARAM", "a")
-#     monkeypatch.setenv("APPLICATION_ID", "b")
-#     monkeypatch.setenv("ALERT_WEBHOOK", "c")
-#     monkeypatch.setenv("CHALLONGE_API_KEY", "d")
-#     monkeypatch.setenv(
-#         "GOOGLE_API_KEY",
-#         "eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6InByb2plY3RfaWQiLCJwcml2YXRlX2tleV9pZCI6ImZkZDhmYWU0MTc1YmU4ZGYwMTlmNTM0NmI2YWNkM2RmYTNjOTQ2OWEiLCJwcml2YXRlX2tleSI6Ii0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLQpNSUlFdkFJQkFEQU5CZ2txaGtpRzl3MEJBUUVGQUFTQ0JLWXdnZ1NpQWdFQUFvSUJBUUQzMEliUWYzazJpMXBpClcza3kvVUJXOGxJZWtjL1VJQ1dmaDFqOXlhaDVaYktnU0NqNXZkeWpVUm90RXNoUzd6a3daSVkwRjlMYS9QSEEKcmdHTjkwZzIrd0EwaWJqSkFqdVloMG8xbTdVY24zeGlQbkRsVHkxZHpFNmFTcFc5ZGtHUDRVdnZGSHgxSVJaUQpTSmRFVkQ4aTBMVkRXd2N3MDZ6Tkh4R3hEMEVwVVVIQk9aRkp3SStVR2Z1ZndVWHNCZkRuZTRjdk9qblJkS1RRCnpFRjc0WG1jeTlMaGtRZVFSbktTRm5FVzhpSHNXRUw5OXVQUUxPa1crTHJIc0dlVXlWbVZMTW5NY01yei9OVTkKMlJIQ2ZmdW83dytBRFdsVmszbVRJV2J2SU4vWEd5NW44elprdTZiWWJ0Z3J0K2dKUVRCdHJ0eks0bDJpWkRpUQplZkhxckpQVkFnTUJBQUVDZ2dFQVJRRlFpeGMvenYwem1qY1M0ZFIzQWUwSWJSZDZPUDAwZ3BZU0QzeFQ5ZmI2CnZ2YzRBc0dIQWZ5aFlnaHFFZEJpM01yd0lzQksxUkVlUktKT1RSaG5FTlRidDkxMzlHWVZMMmFqY29DWTFqejkKT2ZpTTgxanRCQWg5L2FoQVhKYjNkK2N4VlhpUVhIeG1YdzlSVWtKNlRUeWl2NzE5anBQNGpDeTh2SWFvaExTcwpwU1VTWFRYK05EdU50Z1B2VHJKRXVoemtqTzZIWkF5b0c1WGlwRWt3UTRYUjJlTlNTZnpwUG1JTk1lUVd1MHRlCk9PdjlsOTROV3BtQU5qeHVlRFNjYXJmVVFlRmMzS0pHRlZYeG94L2ROMThObzJudGNQaW1RWXU5VHpYY0kvejUKVzlJOWxjeVNXQ0E3amFtZVFvTW9pTThPeVZidmR5RS8zQU9Qb1AyOXBRS0JnUURha1UwcUxMOGROV0dXbXk2cQo1UWtnRERTcGJHYVQ3NzFJcElkMzF5bndMbHdCejNKS1hjUk9GVjJWOGVSWm9FOWFJNzRHV0JwRHpObE1ZbVFZClo0NlZ5aWdINW9JNnU1a2g4L0FhSGNtYkxLaUNuZnRUVEZzQ1VINGF4aERyMVBIT09teG9UdStocVlETzgzajUKRnREZnNqR0pvQUEyQmg3Q3phQisvS084U3dLQmdRRFhTNHE1T24ySkI3N1dCZkIvd2s2WXVndmtsQXRDdHJ0UwpvNk03enRGN1ZkYURNTTJtTXRHRmkwNmlKVHo1WFRaNnFIRDIrL0VyY3FjV0ZDd1RzWmY5UDFDNTdrZmxIZHJOCk5sTzhXb2Ztd0kxTG9JTUQvcENONFJhK3ZrMkhGb2lzYzBtV09CSDJkb3NGN0I2Tm1DTkRuSm5FUDFwNDlUZmUKOGVYREZnU2NYd0tCZ0V0SngrbmlOZ2JxcjI0QWtJZS9rM0FkcERwRUkrV0xySWtNVzdtMVBUWUYwaDJ4aHE0RgpOS3l0QVdxNFF5OTRZRDB0bUxSNHZydGlJZXdFN0hQWG9DOEt6dFZCMnRRK2NOWllQL25QRHZaTDROUDFkWEJSCkdmeG5HN2svUnU3bGtGRzRvRVVpQTd1Tk50aVMxN1g5M1A5aFUxMFQ1MTYwcHYzMWRQYXBNZ0dYQW9HQUxtNTIKVHBoVXRwYmJDMkZnaXMwbkVqMGRqNEIySlQ4dml4VUxnVHlMWlNRUURWOGJHdnJld1FSWVF4UHc0SDYvM3hndwp0TE9GUWErS1pYS1lSdThJTG0vWFF5SW1rejByRVJMa1lEek9EbS84aVJEbThKZVlLV0VmL0tjaUpUNHczN0JGCmNJWkxLWEpMYlUyTkVWQjhXbnFObHd0cXdhZHhFejNzSlhTOExkVUNnWUFNK0hlMUdGUXlPa0ppRDRWS0pKYXUKM2NTT3RETGNYdDdyT2ZBaEVsSmsxK3pWL1RRNjBGTlRoRVgyZ1hMbEpYWjVuRWVsRlBZK0FncDVWYlNEYzFkdgpsV2VVbGtBbjFHUThyNUFHK2hIRy91WmRvQ0ZXMFVJWVFEZ3V5ditJMDhiQnZub29lK0RkK2hJYzZIQ2R5N25aCnVxS1kzUnd6WEdSbk00SjBGcitQOHc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCiIsImNsaWVudF9lbWFpbCI6InRlc3RAdGVzdC5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImNsaWVudF9pZCI6IjEwNzYxNTY2MzMyOTk4MjkyMjAxNiIsImF1dGhfdXJpIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLCJ0b2tlbl91cmkiOiJodHRwczovL29hdXRoMi5nb29nbGVhcGlzLmNvbS90b2tlbiIsImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL29hdXRoMi92MS9jZXJ0cyIsImNsaWVudF94NTA5X2NlcnRfdXJsIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vcm9ib3QvdjEvbWV0YWRhdGEveDUwOS90ZXN0LTg1MiU0MHRlc3QuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJ1bml2ZXJzZV9kb21haW4iOiJnb29nbGVhcGlzLmNvbSJ9Cg==",
-#     )
-#     monkeypatch.setenv("GOOGLE_SHEET_ID", "f")
-#     monkeypatch.setenv("DEBUG", "true")
-
-
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
 def test_calculate_team_seed():
     rating, message = main.calculate_team_seed([2330, 1895])
     assert rating == 2185
@@ -109,45 +88,66 @@ def test_calculate_team_seed():
 def test_get_checkin_status():
     client = MagicMock()
     client.get_parameter.return_value = {"Parameter": {"Value": "disabled"}}
-    status = main.get_checkin_status(client, "a")
+    status = main.get_checkin_status(client, "checkin-status-param")
     assert status == "disabled"
+    client.get_parameter.assert_called_once_with(Name="checkin-status-param")
 
 
 def test_set_checkin_status_enabled():
     client = MagicMock()
+    client.get_parameter.return_value = {"Parameter": {"Value": "disabled"}}
     client.put_parameter.return_value = {}
     event = {
         "data": {
             "options": [
                 {
                     "name": "checkin_enabled",
-                    "options": [
-                        {
-                            "name": "checkin_enabled",
-                            "value": "day_1",
-                        }
-                    ],
+                    "options": [{"name": "checkin_enabled", "value": "day_1"}],
                 }
             ]
         }
     }
-    message = main.set_checkin_status(client, event, "a")
+    message = main.set_checkin_status(client, event, "checkin-status-param")
     assert message == "Checkins are now set to `day_1`"
+    client.put_parameter.assert_called_once_with(
+        Name="checkin-status-param", Value="day_1", Overwrite=True
+    )
 
 
+def test_set_checkin_status_already_set():
+    client = MagicMock()
+    client.get_parameter.return_value = {"Parameter": {"Value": "day_1"}}
+    event = {
+        "data": {
+            "options": [
+                {
+                    "name": "checkin_enabled",
+                    "options": [{"name": "checkin_enabled", "value": "day_1"}],
+                }
+            ]
+        }
+    }
+    message = main.set_checkin_status(client, event, "checkin-status-param")
+    assert message == "Checkins already set to `day_1`"
+    client.put_parameter.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# generate_divisions -- division generation
+#
+# Expected division sizes / counts are derived from running the *current*
+# unmodified `generate_divisions` against the inputs below. With MAX_TEAMS=176
+# none of these inputs hit the team cap, so no teams are ever excluded.
+# ---------------------------------------------------------------------------
 def test_divs_leftover_teams():
     run_generate_divisions(
         i_teams=106,
         i_solos=11,
-        o_divs_0=8,
-        o_divs_1=16,
-        o_divs_2=32,
-        o_divs_3=32,
-        o_divs_4=16,
-        o_playing_teams=main.MAX_TEAMS,
-        o_playing_solos=0,
-        o_excluded_teams=2,
-        o_excluded_solos=11,
+        o_div_sizes=[8, 8, 31, 64, 0],
+        o_playing_teams=111,
+        o_playing_solos=10,
+        o_excluded_teams=0,
+        o_excluded_solos=1,
     )
 
 
@@ -155,15 +155,11 @@ def test_divs_leftover_solos():
     run_generate_divisions(
         i_teams=90,
         i_solos=35,
-        o_divs_0=8,
-        o_divs_1=16,
-        o_divs_2=32,
-        o_divs_3=32,
-        o_divs_4=16,
-        o_playing_teams=main.MAX_TEAMS,
-        o_playing_solos=28,
+        o_div_sizes=[8, 8, 27, 64, 0],
+        o_playing_teams=107,
+        o_playing_solos=34,
         o_excluded_teams=0,
-        o_excluded_solos=7,
+        o_excluded_solos=1,
     )
 
 
@@ -171,11 +167,7 @@ def test_divs_sizes_lt_72_teams():
     run_generate_divisions(
         i_teams=69,
         i_solos=3,
-        o_divs_0=8,
-        o_divs_1=16,
-        o_divs_2=16,
-        o_divs_3=14,
-        o_divs_4=16,
+        o_div_sizes=[8, 8, 16, 22, 16],
         o_playing_teams=70,
         o_playing_solos=2,
         o_excluded_teams=0,
@@ -187,11 +179,7 @@ def test_divs_sizes_gt_72_teams():
     run_generate_divisions(
         i_teams=70,
         i_solos=9,
-        o_divs_0=8,
-        o_divs_1=16,
-        o_divs_2=16,
-        o_divs_3=18,
-        o_divs_4=16,
+        o_div_sizes=[8, 8, 16, 26, 16],
         o_playing_teams=74,
         o_playing_solos=8,
         o_excluded_teams=0,
@@ -203,13 +191,148 @@ def test_divs_sizes_gt_88_teams():
     run_generate_divisions(
         i_teams=80,
         i_solos=22,
-        o_divs_0=8,
-        o_divs_1=16,
-        o_divs_2=32,
-        o_divs_3=19,
-        o_divs_4=16,
+        o_div_sizes=[8, 8, 32, 27, 16],
         o_playing_teams=91,
         o_playing_solos=22,
         o_excluded_teams=0,
         o_excluded_solos=0,
+    )
+
+
+def test_divs_teams_only_no_solos():
+    """All-team field: solos list is returned untouched as excluded_solos."""
+    run_generate_divisions(
+        i_teams=64,
+        i_solos=0,
+        o_div_sizes=[8, 8, 16, 16, 16],
+        o_playing_teams=64,
+        o_playing_solos=0,
+        o_excluded_teams=0,
+        o_excluded_solos=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# sort_signups -- division generation + Sheet and Challonge writes
+# ---------------------------------------------------------------------------
+def _sort_event(confirmed=True):
+    return {
+        "data": {
+            "options": [
+                {
+                    "name": "sort_signups",
+                    "options": [{"name": "confirm", "value": confirmed}],
+                }
+            ]
+        }
+    }
+
+
+def _stub_challonge():
+    """A Challonge stub whose tournaments all exist."""
+    challonge = MagicMock()
+    challonge._get_tournament.return_value = {"tournament": {"id": 1}}
+    return challonge
+
+
+def test_sort_signups_cancelled_when_unconfirmed():
+    gsheet = MagicMock()
+    challonge = MagicMock()
+
+    message = main.sort_signups(_sort_event(confirmed=False), gsheet, challonge)
+
+    assert message == "Cancelled"
+    gsheet.get_all_checkins.assert_not_called()
+    challonge.add_participants_to_tournament.assert_not_called()
+
+
+def test_sort_signups_missing_challonge_tournament_lookup_returns_falsy():
+    """CHARACTERIZATION OF A KNOWN BUG.
+
+    When `_get_tournament` returns falsy (tournament absent) *without*
+    raising, `sort_signups` appends to `missing_challonges` but never binds
+    `f_missing` -- so the missing-tournament return statement raises
+    `UnboundLocalError`. `lambda_handler` wraps the call in a try/except, so
+    in production this surfaces as the generic ":warning: Command failed
+    unexpectedly" message. Pinned here so a later refactor is shown to
+    preserve (or deliberately change) this behaviour.
+    """
+    gsheet = MagicMock()
+    challonge = MagicMock()
+    challonge._get_tournament.return_value = None
+
+    with pytest.raises(UnboundLocalError):
+        main.sort_signups(_sort_event(), gsheet, challonge)
+
+    gsheet.get_all_checkins.assert_not_called()
+
+
+def test_sort_signups_missing_challonge_tournament_lookup_raises():
+    """When `_get_tournament` raises, the except branch binds `f_missing`
+    and the handler returns the missing-tournaments message."""
+    gsheet = MagicMock()
+    challonge = MagicMock()
+    challonge._get_tournament.side_effect = Exception("challonge unavailable")
+
+    message = main.sort_signups(_sort_event(), gsheet, challonge)
+
+    assert message.startswith(":no_entry: Tournaments are missing in Challonge:")
+    gsheet.get_all_checkins.assert_not_called()
+
+
+def test_sort_signups_writes_to_sheets_and_challonge():
+    teams, solos = generate_checkins(64, 0)
+    gsheet = MagicMock()
+    gsheet.get_all_checkins.return_value = (teams, solos)
+    gsheet.write_teams_to_div_sheets.return_value = True
+    challonge = _stub_challonge()
+
+    message = main.sort_signups(_sort_event(), gsheet, challonge)
+
+    # Sheet write happens exactly once with the generated divisions.
+    gsheet.write_teams_to_div_sheets.assert_called_once()
+    written_divisions = gsheet.write_teams_to_div_sheets.call_args[0][0]
+    assert [len(d) for d in written_divisions] == [8, 8, 16, 16, 16]
+
+    # The handler calls add_participants_to_tournament twice (an unguarded
+    # call followed by a try/except'd call) -- pin that current behaviour.
+    assert challonge.add_participants_to_tournament.call_count == 2
+
+    assert message.startswith(
+        ":white_check_mark: Teams sorted in GSheets and added to Challonge:"
+    )
+    assert "Team Signups: 64" in message
+    assert "Solo Signups: 0" in message
+    assert "Total Teams Playing: 64" in message
+
+
+def test_sort_signups_failed_sheet_write():
+    teams, solos = generate_checkins(64, 0)
+    gsheet = MagicMock()
+    gsheet.get_all_checkins.return_value = (teams, solos)
+    gsheet.write_teams_to_div_sheets.return_value = False
+    challonge = _stub_challonge()
+
+    message = main.sort_signups(_sort_event(), gsheet, challonge)
+
+    assert message == (
+        ":warning: Failed to write teams to division sheets or Challonge"
+    )
+    challonge.add_participants_to_tournament.assert_not_called()
+
+
+def test_sort_signups_challonge_write_failure():
+    teams, solos = generate_checkins(64, 0)
+    gsheet = MagicMock()
+    gsheet.get_all_checkins.return_value = (teams, solos)
+    gsheet.write_teams_to_div_sheets.return_value = True
+    challonge = _stub_challonge()
+    # First add succeeds, second add raises HTTPError -> caught and reported.
+    challonge.add_participants_to_tournament.side_effect = [None, HTTPError()]
+
+    message = main.sort_signups(_sort_event(), gsheet, challonge)
+
+    assert message == (
+        ":warning: Successfully sorted teams but failed to add all teams "
+        "to Challonge tournaments"
     )

--- a/src/tests/test_manage.py
+++ b/src/tests/test_manage.py
@@ -26,8 +26,10 @@ def generate_checkins(num_teams, num_solos):
 
     `generate_divisions` only branches on *counts* and relative rating order,
     so the random ratings here do not affect the division *sizes* that the
-    characterization assertions below pin.
+    characterization assertions below pin. A fixed seed keeps the generated
+    ratings reproducible so any future failure can be replayed.
     """
+    random.seed(0)
     teams = []
     for i in range(num_teams):
         teams.append(

--- a/src/tests/test_platform.py
+++ b/src/tests/test_platform.py
@@ -1,0 +1,150 @@
+"""
+Tests for the `libs.platform` parallel-run notifier (issue #118).
+
+`post_to_platform` is a fire-and-forget, fail-open helper: it POSTs an event
+to the new tournament platform's `/legacy/*` bridge endpoints. It must NEVER
+raise -- every failure mode (timeout, connection error, HTTP non-2xx) is
+swallowed so the calling Lambda handler is unaffected.
+
+The HTTP boundary (`requests.post`) is mocked; no test makes a real network
+call.
+"""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from libs import platform
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _response(status_code=200):
+    res = MagicMock()
+    res.status_code = status_code
+
+    def raise_for_status():
+        if status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{status_code} error")
+
+    res.raise_for_status.side_effect = raise_for_status
+    return res
+
+
+@pytest.fixture(autouse=True)
+def _platform_config(monkeypatch):
+    """Point the notifier at a fake, non-routable platform by default."""
+    monkeypatch.setenv("PLATFORM_BASE_URL", "https://platform.invalid")
+    monkeypatch.setenv("LEGACY_BRIDGE_SECRET", "test-bridge-secret")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+@patch("libs.platform.requests.post")
+def test_post_to_platform_success(mock_post):
+    mock_post.return_value = _response(200)
+
+    result = platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    assert result is True
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    # Endpoint is the configured base URL joined with the given path.
+    assert args[0] == "https://platform.invalid/legacy/checkin"
+    # Payload is sent as JSON.
+    assert kwargs["json"] == {"team_name": "Rocket"}
+    # Shared secret travels in the agreed header.
+    assert kwargs["headers"]["x-legacy-bridge-secret"] == "test-bridge-secret"
+    # A short timeout is set so a slow platform cannot stall the handler.
+    assert "timeout" in kwargs
+    assert kwargs["timeout"] > 0
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_trims_slashes(mock_post):
+    """Base URL trailing slash + path leading slash never double up."""
+    mock_post.return_value = _response(200)
+
+    with patch.dict("os.environ", {"PLATFORM_BASE_URL": "https://platform.invalid/"}):
+        platform.post_to_platform("legacy/sort", {"divisions": []})
+
+    args, _ = mock_post.call_args
+    assert args[0] == "https://platform.invalid/legacy/sort"
+
+
+# ---------------------------------------------------------------------------
+# Swallowed failure modes -- the helper must never raise
+# ---------------------------------------------------------------------------
+@patch("libs.platform.requests.post")
+def test_post_to_platform_swallows_timeout(mock_post):
+    mock_post.side_effect = requests.exceptions.Timeout("timed out")
+
+    # Must not raise.
+    result = platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    assert result is False
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_swallows_connection_error(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError("refused")
+
+    result = platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    assert result is False
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_swallows_http_500(mock_post):
+    mock_post.return_value = _response(500)
+
+    result = platform.post_to_platform("/legacy/results", {"winning_score": 2})
+
+    assert result is False
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_swallows_http_401(mock_post):
+    """A wrong/missing secret (401 on the platform) is also swallowed."""
+    mock_post.return_value = _response(401)
+
+    result = platform.post_to_platform("/legacy/sort", {"divisions": []})
+
+    assert result is False
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_swallows_unexpected_error(mock_post):
+    """Any non-requests exception is swallowed too -- truly fail-open."""
+    mock_post.side_effect = ValueError("something weird")
+
+    result = platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    assert result is False
+
+
+def test_post_to_platform_skips_when_unconfigured(monkeypatch):
+    """With no base URL configured the helper no-ops without touching HTTP."""
+    monkeypatch.delenv("PLATFORM_BASE_URL", raising=False)
+    monkeypatch.delenv("LEGACY_BRIDGE_SECRET", raising=False)
+
+    with patch("libs.platform.requests.post") as mock_post:
+        result = platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    assert result is False
+    mock_post.assert_not_called()
+
+
+@patch("libs.platform.requests.post")
+def test_post_to_platform_logs_but_does_not_raise_on_failure(mock_post, caplog):
+    mock_post.side_effect = requests.exceptions.Timeout("timed out")
+
+    with caplog.at_level(logging.WARNING):
+        platform.post_to_platform("/legacy/checkin", {"team_name": "Rocket"})
+
+    # The failure is observable in logs (for the parallel-run audit) ...
+    assert any("platform" in rec.message.lower() for rec in caplog.records)

--- a/src/tests/test_platform.py
+++ b/src/tests/test_platform.py
@@ -139,6 +139,18 @@ def test_post_to_platform_skips_when_unconfigured(monkeypatch):
     mock_post.assert_not_called()
 
 
+def test_post_to_platform_skips_on_empty_path(monkeypatch):
+    """An empty path would otherwise POST to the base URL itself -- skip."""
+    monkeypatch.setenv("PLATFORM_BASE_URL", "https://platform.example/")
+    monkeypatch.setenv("LEGACY_BRIDGE_SECRET", "shh")
+
+    with patch("libs.platform.requests.post") as mock_post:
+        result = platform.post_to_platform("", {"team_name": "Rocket"})
+
+    assert result is False
+    mock_post.assert_not_called()
+
+
 @patch("libs.platform.requests.post")
 def test_post_to_platform_logs_but_does_not_raise_on_failure(mock_post, caplog):
     mock_post.side_effect = requests.exceptions.Timeout("timed out")

--- a/src/tests/test_platform_hooks.py
+++ b/src/tests/test_platform_hooks.py
@@ -1,0 +1,424 @@
+"""
+Tests for the parallel-run platform-bridge hooks wired into the
+`checkin`, `manage`/`sort_signups` and `results` handlers (issue #118).
+
+Two layers are covered:
+
+* the pure payload builders (`build_checkin_payload`, `build_sort_payload`),
+  which translate handler data into the `/legacy/*` request shapes; and
+* the `lambda_handler` integration -- that `post_to_platform` is invoked,
+  with the right endpoint and payload, AFTER the Discord reply, and that a
+  failing bridge call never breaks the handler.
+
+`post_to_platform` and every external service are mocked; no test makes a
+real network call.
+"""
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from checkin import main as checkin_main
+from manage import main as manage_main
+from results import main as results_main
+
+
+# ===========================================================================
+# checkin -- build_checkin_payload
+# ===========================================================================
+def _team_checkin_event(team_name="Team Rocket", channel_id="1023401872750547014"):
+    return {
+        "token": "tok",
+        "channel_id": channel_id,
+        "data": {
+            "options": [
+                {"name": "team", "options": [{"name": "team", "value": team_name}]}
+            ]
+        },
+        "member": {
+            "nick": "Bob",
+            "user": {"id": "discord-123", "global_name": "BobG", "username": "bob"},
+        },
+    }
+
+
+def _solo_checkin_event(nick="Alice", channel_id="1023401872750547014", user=None):
+    return {
+        "token": "tok",
+        "channel_id": channel_id,
+        "data": {"options": [{"name": "solo"}]},
+        "member": {
+            "nick": nick,
+            "user": user
+            if user is not None
+            else {"id": "discord-999", "global_name": "AliceG", "username": "alice"},
+        },
+    }
+
+
+def test_build_checkin_payload_team():
+    payload = checkin_main.build_checkin_payload(
+        _team_checkin_event(team_name="Winners"), "day_2"
+    )
+    assert payload == {"team_name": "Winners", "day": "day_2"}
+
+
+def test_build_checkin_payload_solo_with_discord_id():
+    payload = checkin_main.build_checkin_payload(_solo_checkin_event(nick="Alice"), "day_1")
+    assert payload == {
+        "player_name": "Alice",
+        "day": "day_1",
+        "discord_user_id": "discord-999",
+    }
+
+
+def test_build_checkin_payload_solo_name_fallback():
+    """nick -> global_name -> username fallback, mirroring `checkin()`."""
+    event = _solo_checkin_event(
+        nick="", user={"global_name": "", "username": "fallback_user"}
+    )
+    payload = checkin_main.build_checkin_payload(event, "day_1")
+    assert payload["player_name"] == "fallback_user"
+    # No Discord id available -> field omitted.
+    assert "discord_user_id" not in payload
+
+
+# ===========================================================================
+# checkin -- lambda_handler hook
+# ===========================================================================
+@patch("checkin.main.post_to_platform")
+@patch("checkin.main.boto3")
+@patch("checkin.main.Discord")
+@patch("checkin.main.checkin")
+def test_checkin_handler_notifies_platform_after_reply(
+    mock_checkin, mock_discord_cls, mock_boto3, mock_post
+):
+    discord = mock_discord_cls.return_value
+    mock_checkin.return_value = ":white_check_mark: ok"
+    mock_boto3.client.return_value.get_parameter.return_value = {
+        "Parameter": {"Value": "day_1"}
+    }
+
+    checkin_main.lambda_handler(_team_checkin_event(team_name="Rocket"), MagicMock())
+
+    mock_post.assert_called_once_with(
+        "/legacy/checkin", {"team_name": "Rocket", "day": "day_1"}
+    )
+    # The platform call happens AFTER the Discord reply.
+    assert discord.message_response.called
+
+
+@patch("checkin.main.post_to_platform")
+@patch("checkin.main.boto3")
+@patch("checkin.main.Discord")
+@patch("checkin.main.checkin")
+def test_checkin_handler_skips_platform_when_checkins_disabled(
+    mock_checkin, mock_discord_cls, mock_boto3, mock_post
+):
+    mock_boto3.client.return_value.get_parameter.return_value = {
+        "Parameter": {"Value": "disabled"}
+    }
+
+    checkin_main.lambda_handler(_team_checkin_event(), MagicMock())
+
+    mock_post.assert_not_called()
+
+
+@patch("checkin.main.post_to_platform")
+@patch("checkin.main.boto3")
+@patch("checkin.main.Discord")
+@patch("checkin.main.checkin")
+def test_checkin_handler_unaffected_by_bridge_failure(
+    mock_checkin, mock_discord_cls, mock_boto3, mock_post
+):
+    """A raising bridge hook must not surface as a handler failure."""
+    discord = mock_discord_cls.return_value
+    mock_checkin.return_value = ":white_check_mark: ok"
+    mock_boto3.client.return_value.get_parameter.return_value = {
+        "Parameter": {"Value": "day_1"}
+    }
+    mock_post.side_effect = RuntimeError("bridge exploded")
+
+    # Must not raise.
+    checkin_main.lambda_handler(_team_checkin_event(), MagicMock())
+
+    # The user still got the real reply, not the generic failure message.
+    discord.message_response.assert_called_once_with(":white_check_mark: ok")
+
+
+# ===========================================================================
+# manage -- build_sort_payload
+# ===========================================================================
+def test_build_sort_payload_shape_and_order():
+    divisions = [
+        [
+            {"team": "A", "player_1": "a1", "player_2": "a2", "rating": 2000},
+            {"team": "B", "player_1": "b1", "player_2": "b2", "rating": 1900},
+        ],
+        [
+            {"team": "C", "player_1": "c1", "player_2": "c2", "rating": 1500},
+        ],
+    ]
+
+    payload = manage_main.build_sort_payload(divisions)
+
+    assert payload == {
+        "divisions": [
+            {
+                "division_number": 1,
+                "teams": [
+                    {
+                        "team_name": "A",
+                        "player_1": "a1",
+                        "player_2": "a2",
+                        "rating": 2000,
+                    },
+                    {
+                        "team_name": "B",
+                        "player_1": "b1",
+                        "player_2": "b2",
+                        "rating": 1900,
+                    },
+                ],
+            },
+            {
+                "division_number": 2,
+                "teams": [
+                    {
+                        "team_name": "C",
+                        "player_1": "c1",
+                        "player_2": "c2",
+                        "rating": 1500,
+                    }
+                ],
+            },
+        ]
+    }
+
+
+def test_sort_signups_populates_divisions_out():
+    """The optional `divisions_out` accumulator collects the layout without
+    altering the return value."""
+    teams = [
+        {"team": f"T{i}", "player_1": f"p{i}a", "player_2": f"p{i}b", "rating": 1500 + i}
+        for i in range(64)
+    ]
+    gsheet = MagicMock()
+    gsheet.get_all_checkins.return_value = (teams, [])
+    gsheet.write_teams_to_div_sheets.return_value = True
+    challonge = MagicMock()
+    challonge._get_tournament.return_value = {"tournament": {"id": 1}}
+
+    collected = []
+    message = manage_main.sort_signups(
+        {
+            "data": {
+                "options": [
+                    {
+                        "name": "sort_signups",
+                        "options": [{"name": "confirm", "value": True}],
+                    }
+                ]
+            }
+        },
+        gsheet,
+        challonge,
+        collected,
+    )
+
+    assert message.startswith(":white_check_mark:")
+    assert [len(d) for d in collected] == [8, 8, 16, 16, 16]
+
+
+# ===========================================================================
+# manage -- lambda_handler hook
+# ===========================================================================
+@patch("manage.main.post_to_platform")
+@patch("manage.main.GoogleSheet")
+@patch("manage.main.Discord")
+@patch("manage.main.Challonge")
+@patch("manage.main.boto3")
+def test_sort_handler_notifies_platform_after_reply(
+    mock_boto3, mock_challonge_cls, mock_discord_cls, mock_gsheet_cls, mock_post
+):
+    discord = mock_discord_cls.return_value
+    teams = [
+        {"team": f"T{i}", "player_1": f"p{i}a", "player_2": f"p{i}b", "rating": 1500 + i}
+        for i in range(64)
+    ]
+    gsheet = mock_gsheet_cls.return_value
+    gsheet.get_all_checkins.return_value = (teams, [])
+    gsheet.write_teams_to_div_sheets.return_value = True
+    challonge = mock_challonge_cls.return_value
+    challonge._get_tournament.return_value = {"tournament": {"id": 1}}
+
+    event = {
+        "token": "tok",
+        "data": {
+            "options": [
+                {
+                    "name": "sort_signups",
+                    "options": [{"name": "confirm", "value": True}],
+                }
+            ]
+        },
+    }
+    manage_main.lambda_handler(event, MagicMock())
+
+    assert mock_post.call_count == 1
+    endpoint, payload = mock_post.call_args[0]
+    assert endpoint == "/legacy/sort"
+    assert [d["division_number"] for d in payload["divisions"]] == [1, 2, 3, 4, 5]
+    assert [len(d["teams"]) for d in payload["divisions"]] == [8, 8, 16, 16, 16]
+    assert discord.message_response.called
+
+
+@patch("manage.main.post_to_platform")
+@patch("manage.main.GoogleSheet")
+@patch("manage.main.Discord")
+@patch("manage.main.Challonge")
+@patch("manage.main.boto3")
+def test_non_sort_subcommand_does_not_notify_platform(
+    mock_boto3, mock_challonge_cls, mock_discord_cls, mock_gsheet_cls, mock_post
+):
+    """`calculate_seed` and friends never touch the bridge."""
+    event = {
+        "token": "tok",
+        "data": {
+            "options": [
+                {"name": "calculate_seed", "options": [{"value": 2000}, {"value": 1800}]}
+            ]
+        },
+    }
+    manage_main.lambda_handler(event, MagicMock())
+
+    mock_post.assert_not_called()
+
+
+@patch("manage.main.post_to_platform")
+@patch("manage.main.GoogleSheet")
+@patch("manage.main.Discord")
+@patch("manage.main.Challonge")
+@patch("manage.main.boto3")
+def test_sort_handler_unaffected_by_bridge_failure(
+    mock_boto3, mock_challonge_cls, mock_discord_cls, mock_gsheet_cls, mock_post
+):
+    discord = mock_discord_cls.return_value
+    teams = [
+        {"team": f"T{i}", "player_1": f"p{i}a", "player_2": f"p{i}b", "rating": 1500 + i}
+        for i in range(64)
+    ]
+    gsheet = mock_gsheet_cls.return_value
+    gsheet.get_all_checkins.return_value = (teams, [])
+    gsheet.write_teams_to_div_sheets.return_value = True
+    challonge = mock_challonge_cls.return_value
+    challonge._get_tournament.return_value = {"tournament": {"id": 1}}
+    mock_post.side_effect = RuntimeError("bridge exploded")
+
+    event = {
+        "token": "tok",
+        "data": {
+            "options": [
+                {
+                    "name": "sort_signups",
+                    "options": [{"name": "confirm", "value": True}],
+                }
+            ]
+        },
+    }
+    # Must not raise.
+    manage_main.lambda_handler(event, MagicMock())
+
+    # The success reply was delivered, not the generic failure message.
+    assert discord.message_response.call_count == 1
+    assert discord.message_response.call_args[0][0].startswith(":white_check_mark:")
+
+
+# ===========================================================================
+# results -- lambda_handler hook
+# ===========================================================================
+def _results_event(winning_team="Winners", winning_score=2, losing_score=1):
+    return {
+        "token": "tok",
+        "channel_id": "1023401872750547014",  # maps to a real RESULTS tournament id
+        "data": {
+            "options": [
+                {"value": winning_team},
+                {"value": winning_score},
+                {"value": losing_score},
+            ]
+        },
+    }
+
+
+@patch("results.main.post_to_platform")
+@patch("results.main.Discord")
+@patch("results.main.results")
+def test_results_handler_notifies_platform_after_reply(
+    mock_results, mock_discord_cls, mock_post
+):
+    discord = mock_discord_cls.return_value
+
+    def fake_results(event, context, tournament_id, result_out=None):
+        # Simulate the success path populating the accumulator.
+        if result_out is not None:
+            result_out.update(
+                {
+                    "winning_team_name": "Winners",
+                    "winning_score": 2,
+                    "losing_score": 1,
+                }
+            )
+        return ":white_check_mark: recorded"
+
+    mock_results.side_effect = fake_results
+
+    results_main.lambda_handler(_results_event(), MagicMock())
+
+    mock_post.assert_called_once_with(
+        "/legacy/results",
+        {"winning_team_name": "Winners", "winning_score": 2, "losing_score": 1},
+    )
+    assert discord.message_response.called
+
+
+@patch("results.main.post_to_platform")
+@patch("results.main.Discord")
+@patch("results.main.results")
+def test_results_handler_skips_platform_on_non_success(
+    mock_results, mock_discord_cls, mock_post
+):
+    """A short-circuit return (e.g. team not found) leaves the accumulator
+    empty -- nothing is mirrored to the platform."""
+    mock_results.return_value = ":no_entry: Team `Ghost` not found"
+
+    results_main.lambda_handler(_results_event(winning_team="Ghost"), MagicMock())
+
+    mock_post.assert_not_called()
+
+
+@patch("results.main.post_to_platform")
+@patch("results.main.Discord")
+@patch("results.main.results")
+def test_results_handler_unaffected_by_bridge_failure(
+    mock_results, mock_discord_cls, mock_post
+):
+    discord = mock_discord_cls.return_value
+
+    def fake_results(event, context, tournament_id, result_out=None):
+        if result_out is not None:
+            result_out.update(
+                {
+                    "winning_team_name": "Winners",
+                    "winning_score": 2,
+                    "losing_score": 1,
+                }
+            )
+        return ":white_check_mark: recorded"
+
+    mock_results.side_effect = fake_results
+    mock_post.side_effect = RuntimeError("bridge exploded")
+
+    # Must not raise.
+    results_main.lambda_handler(_results_event(), MagicMock())
+
+    discord.message_response.assert_called_once_with(":white_check_mark: recorded")

--- a/src/tests/test_platform_hooks.py
+++ b/src/tests/test_platform_hooks.py
@@ -127,6 +127,25 @@ def test_checkin_handler_skips_platform_when_checkins_disabled(
 @patch("checkin.main.boto3")
 @patch("checkin.main.Discord")
 @patch("checkin.main.checkin")
+def test_checkin_handler_skips_platform_on_non_success(
+    mock_checkin, mock_discord_cls, mock_boto3, mock_post
+):
+    """A failed check-in (e.g. team not found) returns a `:no_entry:`
+    message -- nothing is mirrored to the platform."""
+    mock_checkin.return_value = ":no_entry: `Ghost` not found in the `Sign-up` sheet"
+    mock_boto3.client.return_value.get_parameter.return_value = {
+        "Parameter": {"Value": "day_1"}
+    }
+
+    checkin_main.lambda_handler(_team_checkin_event(team_name="Ghost"), MagicMock())
+
+    mock_post.assert_not_called()
+
+
+@patch("checkin.main.post_to_platform")
+@patch("checkin.main.boto3")
+@patch("checkin.main.Discord")
+@patch("checkin.main.checkin")
 def test_checkin_handler_unaffected_by_bridge_failure(
     mock_checkin, mock_discord_cls, mock_boto3, mock_post
 ):

--- a/src/tests/test_results.py
+++ b/src/tests/test_results.py
@@ -9,6 +9,7 @@ imports -- no test touches a real Challonge API or the network. The handler
 caches participants under `/tmp/{tournament_id}.json`; each test uses a
 unique tournament id and cleans the file up so runs are independent.
 """
+import glob
 import os
 import uuid
 from unittest.mock import MagicMock, patch
@@ -26,7 +27,9 @@ def tournament_id():
     """A unique id per test so the /tmp participant cache never collides."""
     tid = f"test-{uuid.uuid4().hex}"
     yield tid
-    for path in (f"/tmp/{tid}.json",):
+    # Final cache file plus any intermediate `{tid}-{aws_request_id}.json`
+    # leaked by a mid-write failure.
+    for path in [f"/tmp/{tid}.json", *glob.glob(f"/tmp/{tid}-*.json")]:
         if os.path.exists(path):
             os.remove(path)
 

--- a/src/tests/test_results.py
+++ b/src/tests/test_results.py
@@ -1,0 +1,231 @@
+"""
+Characterization tests for the `results` handler.
+
+These pin the *current* behaviour of the unmodified `results` function:
+match lookup against a Challonge tournament and the resulting score update.
+
+Challonge is mocked at the boundary via the `Challonge` class the handler
+imports -- no test touches a real Challonge API or the network. The handler
+caches participants under `/tmp/{tournament_id}.json`; each test uses a
+unique tournament id and cleans the file up so runs are independent.
+"""
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from results import main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def tournament_id():
+    """A unique id per test so the /tmp participant cache never collides."""
+    tid = f"test-{uuid.uuid4().hex}"
+    yield tid
+    for path in (f"/tmp/{tid}.json",):
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def _context():
+    ctx = MagicMock()
+    ctx.aws_request_id = uuid.uuid4().hex
+    return ctx
+
+
+def results_event(winning_team="Winners", winning_score=2, losing_score=1):
+    return {
+        "data": {
+            "options": [
+                {"value": winning_team},
+                {"value": winning_score},
+                {"value": losing_score},
+            ]
+        }
+    }
+
+
+def participant(pid, name, group_player_ids=None):
+    return {
+        "participant": {
+            "id": pid,
+            "name": name,
+            "group_player_ids": group_player_ids or [],
+        }
+    }
+
+
+def match(match_id, player1_id, player2_id, state="open", round_=1):
+    return {
+        "match": {
+            "id": match_id,
+            "player1_id": player1_id,
+            "player2_id": player2_id,
+            "state": state,
+            "round": round_,
+        }
+    }
+
+
+def make_challonge(
+    state="underway",
+    name="Test Cup",
+    participants=None,
+    matches=None,
+    losing_participant_name="Losers",
+):
+    """Build a mock Challonge instance for `results.main.Challonge`."""
+    challonge = MagicMock()
+    challonge._get_tournament.return_value = {
+        "tournament": {"state": state, "name": name}
+    }
+    challonge._get_participants.return_value = participants or []
+    challonge._get_matches.return_value = matches or []
+    challonge._get_participant.return_value = {
+        "participant": {"name": losing_participant_name}
+    }
+    challonge._update_match.return_value = {}
+    return challonge
+
+
+# ---------------------------------------------------------------------------
+# Tournament-state short-circuits
+# ---------------------------------------------------------------------------
+@patch("results.main.Challonge")
+def test_results_tournament_pending(mock_challonge_cls, tournament_id):
+    mock_challonge_cls.return_value = make_challonge(state="pending")
+
+    message = main.results(results_event(), _context(), tournament_id)
+
+    assert message.startswith(":no_entry: Test Cup has not started yet")
+
+
+@patch("results.main.Challonge")
+def test_results_tournament_complete(mock_challonge_cls, tournament_id):
+    mock_challonge_cls.return_value = make_challonge(state="complete")
+
+    message = main.results(results_event(), _context(), tournament_id)
+
+    assert message == ":no_entry: Test Cup has finished"
+
+
+# ---------------------------------------------------------------------------
+# Score validation
+# ---------------------------------------------------------------------------
+@patch("results.main.Challonge")
+def test_results_winning_score_not_higher(mock_challonge_cls, tournament_id):
+    mock_challonge_cls.return_value = make_challonge(state="underway")
+
+    message = main.results(
+        results_event(winning_score=1, losing_score=1), _context(), tournament_id
+    )
+
+    assert message == (
+        ":no_entry: Winning score `1` must be higher than losing score `1`"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Match lookup
+# ---------------------------------------------------------------------------
+@patch("results.main.Challonge")
+def test_results_team_not_found(mock_challonge_cls, tournament_id):
+    challonge = make_challonge(
+        state="underway",
+        participants=[participant(101, "SomeOtherTeam")],
+    )
+    mock_challonge_cls.return_value = challonge
+
+    message = main.results(
+        results_event(winning_team="Winners"), _context(), tournament_id
+    )
+
+    assert message.startswith(":no_entry: Team `Winners` not found")
+    challonge._update_match.assert_not_called()
+
+
+@patch("results.main.Challonge")
+def test_results_no_open_match(mock_challonge_cls, tournament_id):
+    challonge = make_challonge(
+        state="underway",
+        participants=[participant(101, "Winners"), participant(102, "Losers")],
+        matches=[match(900, 101, 102, state="complete")],
+    )
+    mock_challonge_cls.return_value = challonge
+
+    message = main.results(
+        results_event(winning_team="Winners"), _context(), tournament_id
+    )
+
+    assert message.startswith(":no_entry: No match in progress for Winners")
+    challonge._update_match.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Successful score update
+# ---------------------------------------------------------------------------
+@patch("results.main.Challonge")
+def test_results_score_update_winner_is_player1(mock_challonge_cls, tournament_id):
+    challonge = make_challonge(
+        state="underway",
+        participants=[participant(101, "Winners"), participant(102, "Losers")],
+        matches=[match(900, 101, 102, state="open", round_=3)],
+        losing_participant_name="Losers",
+    )
+    mock_challonge_cls.return_value = challonge
+
+    message = main.results(
+        results_event(winning_team="Winners", winning_score=2, losing_score=1),
+        _context(),
+        tournament_id,
+    )
+
+    # winner is player1 -> scores_csv is "winning-losing".
+    challonge._update_match.assert_called_once_with(tournament_id, 900, 101, "2-1")
+    assert message == (
+        ":white_check_mark: [Round 3] `Winners` 2-1 `Losers`"
+    )
+
+
+@patch("results.main.Challonge")
+def test_results_score_update_winner_is_player2(mock_challonge_cls, tournament_id):
+    challonge = make_challonge(
+        state="underway",
+        participants=[participant(101, "Losers"), participant(102, "Winners")],
+        matches=[match(900, 101, 102, state="open", round_=1)],
+        losing_participant_name="Losers",
+    )
+    mock_challonge_cls.return_value = challonge
+
+    message = main.results(
+        results_event(winning_team="Winners", winning_score=3, losing_score=0),
+        _context(),
+        tournament_id,
+    )
+
+    # winner is player2 -> scores_csv is flipped to "losing-winning".
+    challonge._update_match.assert_called_once_with(tournament_id, 900, 102, "0-3")
+    assert message == ":white_check_mark: [Round 1] `Winners` 3-0 `Losers`"
+
+
+@patch("results.main.Challonge")
+def test_results_participants_cache_reused(mock_challonge_cls, tournament_id):
+    """Second invocation reads participants from the /tmp cache file rather
+    than re-fetching them from Challonge."""
+    challonge = make_challonge(
+        state="underway",
+        participants=[participant(101, "Winners"), participant(102, "Losers")],
+        matches=[match(900, 101, 102, state="open")],
+    )
+    mock_challonge_cls.return_value = challonge
+
+    main.results(results_event(winning_team="Winners"), _context(), tournament_id)
+    main.results(results_event(winning_team="Winners"), _context(), tournament_id)
+
+    # Participants fetched once; the cache file served the second call.
+    challonge._get_participants.assert_called_once()
+    assert os.path.exists(f"/tmp/{tournament_id}.json")

--- a/templates/template.py
+++ b/templates/template.py
@@ -72,6 +72,29 @@ def sceptre_handler(sceptre_user_data):
         )
     )
 
+    # Parallel-run bridge to the new tournament platform (issue #118).
+    # An empty PlatformBaseUrl disables the bridge -- the notifier no-ops.
+    platform_base_url = template.add_parameter(
+        Parameter(
+            "PlatformBaseUrl",
+            Description="Base URL of the new tournament platform API "
+            "(parallel-run bridge). Empty disables the bridge.",
+            Type="String",
+            Default="",
+        )
+    )
+
+    legacy_bridge_secret = template.add_parameter(
+        Parameter(
+            "LegacyBridgeSecret",
+            Description="Shared secret for the platform's /legacy/* bridge "
+            "endpoints; sent in the x-legacy-bridge-secret header.",
+            Type="String",
+            Default="",
+            NoEcho=True,
+        )
+    )
+
     # Resources
     checkin_status_param = template.add_resource(
         ssm.Parameter(
@@ -95,6 +118,8 @@ def sceptre_handler(sceptre_user_data):
             "GOOGLE_SHEET_ID": Ref(google_sheet_id),
             "CHECKIN_STATUS_PARAM": Ref(checkin_status_param),
             "ALERT_WEBHOOK": Ref(alert_webhook),
+            "PLATFORM_BASE_URL": Ref(platform_base_url),
+            "LEGACY_BRIDGE_SECRET": Ref(legacy_bridge_secret),
         },
         iam_permissions=[
             {
@@ -121,6 +146,8 @@ def sceptre_handler(sceptre_user_data):
             "GOOGLE_SHEET_ID": Ref(google_sheet_id),
             "CHALLONGE_API_KEY": Ref(challonge_api_key),
             "ALERT_WEBHOOK": Ref(alert_webhook),
+            "PLATFORM_BASE_URL": Ref(platform_base_url),
+            "LEGACY_BRIDGE_SECRET": Ref(legacy_bridge_secret),
         },
         iam_permissions=[],
     )
@@ -138,6 +165,8 @@ def sceptre_handler(sceptre_user_data):
             "GOOGLE_API_KEY": Ref(google_api_key),
             "GOOGLE_SHEET_ID": Ref(google_sheet_id),
             "ALERT_WEBHOOK": Ref(alert_webhook),
+            "PLATFORM_BASE_URL": Ref(platform_base_url),
+            "LEGACY_BRIDGE_SECRET": Ref(legacy_bridge_secret),
         },
         iam_permissions=[
             {


### PR DESCRIPTION
## Summary

Implements the legacy-bot side of the **parallel-run bridge** (epic #111) — lets the legacy Python/AWS-Lambda Discord bot fire-and-forward its actions to the new Cloudflare-Worker tournament platform during migration, without changing any existing behaviour. First revives the dormant pytest suite and pins current handler behaviour with characterization tests (the safety net), then adds a fail-open `post_to_platform()` notifier wired as fire-and-forget hooks into the `checkin`, `sort_signups`, and `results` handlers. Every change is non-blocking, fail-open, and purely additive — the unmaintained legacy handlers keep all existing Google Sheets / Challonge writes. Delivered autonomously via the `ship-it` skill; each issue was implemented test-first and passed a two-stage review plus a whole-branch final review.

## Completed

- **#112 — pytest revival + characterization tests** (`0198d92`) — revived the pytest suite (`pytest.ini`, documented run command) and added 37 characterization tests pinning the current behaviour of the `checkin`, `manage` `sort_signups`, and `results` handlers, all external services mocked. No handler code changed.
- **#118 — platform notifier + fire-and-forget hooks** (`b6f7d78`) — `src/libs/platform.py`: a synchronous, short-timeout, fully fail-open `post_to_platform()` HTTP helper carrying the `x-legacy-bridge-secret` header; wired into the three handlers after the Discord reply (no user-visible latency). Optional `None`-default accumulator params keep existing call sites and the #112 tests untouched. Config delivered via Sceptre/Troposphere stack parameters.

Supporting commit: `50d4050` (whole-branch final-review fix — the `checkin` hook now fires only on a successful check-in, consistent with the `sort`/`results` hooks, instead of mirroring failed check-ins).

Full suite verified green: 61 tests (37 characterization + 24 new notifier/hook tests).

## Known issue (intentionally not fixed)

`sort_signups` in `src/manage/main.py` has a pre-existing `UnboundLocalError` when `challonge._get_tournament()` returns a falsy value without raising. Per epic #111's "absolute minimal, behaviour-preserving change" mandate, #112 *pinned* this bug with a characterization test rather than fixing it — fixing legacy behaviour was out of scope. Worth a follow-up issue.

## Deferred (Suggestion-level review findings, not blocking)

- `test_checkin.py` has an unused `import pytest`; the `test_results.py` fixture could glob-clean `/tmp/{tid}-*.json`; a fixed `random.seed` would make `generate_checkins` reproducible.
- `platform.py` URL build would yield a trailing slash on an empty `path` (no current caller does this); the three hooks use slightly different gating styles — a clarifying comment would help.
- The `/legacy/results` payload carries no tournament/match identifier — confirm the platform side needs none.
- `pytest.ini` hard-codes a decode-able `GOOGLE_API_KEY` stub; a comment noting it is a placeholder would prevent future confusion.

## Pending human work

None — both bot-repo children of epic #111 were `ready-for-agent`.

## Test plan

- [ ] `python3 -m venv .venv && .venv/bin/pip install pytest pytest-mock pytest-env pynacl gspread requests boto3 && .venv/bin/pytest` — 61 tests pass.
- [ ] With `PLATFORM_BASE_URL` + `LEGACY_BRIDGE_SECRET` set, a real check-in/sort/results action fire-and-forwards to the platform's `/legacy/*` endpoints; with an empty base URL the bridge no-ops.
- [ ] A platform-side failure (timeout, 5xx, connection error) never affects the Discord-facing handler response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
